### PR TITLE
iframe: fix positioning on website

### DIFF
--- a/doc/pipe.css
+++ b/doc/pipe.css
@@ -809,7 +809,7 @@ a:hover {
 #frame {
   position: absolute;
   top: -140px;
-  left: -270px;
+  left: -250px;
   width: 1086px;
   height: 1200px;
 }


### PR DESCRIPTION
footer and headlines got sliced of a bit and there was a grey
line on the right

Headlines:
![bildschirmfoto 2014-09-18 um 20 51 00](https://cloud.githubusercontent.com/assets/298166/4325388/c64e9ed6-3f64-11e4-84a1-968f21aef3d1.png)

Grey line on the right:
![bildschirmfoto 2014-09-18 um 18 06 59](https://cloud.githubusercontent.com/assets/298166/4325370/95bf80e6-3f64-11e4-98c3-285abd8230d0.png)

Footer:
![bildschirmfoto 2014-09-18 um 18 06 53](https://cloud.githubusercontent.com/assets/298166/4325371/972f9f1a-3f64-11e4-925d-9d620294b11b.png)
