### PR TITLE
add advisory board charter github source link

### DIFF
--- a/doc/about/advisory-board/index.md
+++ b/doc/about/advisory-board/index.md
@@ -211,3 +211,5 @@ Board position.  Read more about the announcement
 
 Please help us improve this draft by sending your comments and feedback to
 [governance@nodejs.org](mailto:governance@nodejs.org).
+
+The source for this document can be found [in this repository](https://github.com/joyent/node-website/tree/master/doc/about/advisory-board).


### PR DESCRIPTION
this just adds a link to the source markdown so people can e.g. easily view history, be empowered to propose changes more easily etc
