### PR TITLE
Use uppercase written `Node.js`

### DIFF
--- a/doc/about.html
+++ b/doc/about.html
@@ -13,7 +13,7 @@
           type="application/rss+xml"
           title="node blog"
           href="http://feeds.feedburner.com/nodejs/123123123">
-    <title>__TITLE__ | node.js</title>
+    <title>__TITLE__ | Node.js</title>
   </head>
 
   <body class="int alt" id="docs">

--- a/doc/about/advisory-board/template.html
+++ b/doc/about/advisory-board/template.html
@@ -13,7 +13,7 @@
           type="application/rss+xml"
           title="node blog"
           href="http://feeds.feedburner.com/nodejs/123123123">
-    <title>__TITLE__ | node.js</title>
+    <title>__TITLE__ | Node.js</title>
   </head>
 
   <body class="int alt" id="docs">

--- a/doc/contributing.html
+++ b/doc/contributing.html
@@ -13,7 +13,7 @@
           type="application/rss+xml"
           title="node blog"
           href="http://feeds.feedburner.com/nodejs/123123123">
-    <title>__TITLE__ | node.js</title>
+    <title>__TITLE__ | Node.js</title>
   </head>
 
   <body class="int alt" id="__TITLE__">

--- a/doc/docs.html
+++ b/doc/docs.html
@@ -13,7 +13,7 @@
           type="application/rss+xml"
           title="node blog"
           href="http://feeds.feedburner.com/nodejs/123123123">
-    <title>__TITLE__ | node.js</title>
+    <title>__TITLE__ | Node.js</title>
   </head>
 
   <body class="int alt" id="docs">

--- a/doc/download/index.html
+++ b/doc/download/index.html
@@ -12,7 +12,7 @@
           type="application/rss+xml"
           title="node blog"
           href="http://feeds.feedburner.com/nodejs/123123123">
-    <title>node.js</title>
+    <title>Node.js</title>
   </head>
   <body class="int alt" id="download">
     <div id="nav">

--- a/doc/index.html
+++ b/doc/index.html
@@ -12,7 +12,7 @@
           type="application/rss+xml"
           title="node blog"
           href="http://feeds.feedburner.com/nodejs/123123123">
-    <title>node.js</title>
+    <title>Node.js</title>
   </head>
   <body id="front">
     <div id="nav">

--- a/doc/website.html
+++ b/doc/website.html
@@ -13,7 +13,7 @@
           type="application/rss+xml"
           title="node blog"
           href="http://feeds.feedburner.com/nodejs/123123123">
-    <title>__TITLE__ | node.js</title>
+    <title>__TITLE__ | Node.js</title>
   </head>
 
   <body class="int alt" id="__FILENAME__">


### PR DESCRIPTION
Use `Node.js` instead of `node.js` in titles, like everywhere
