### PR TITLE
Fix typo in Contributing Section

### DIFF
--- a/doc/documentation/contributing/index.md
+++ b/doc/documentation/contributing/index.md
@@ -28,7 +28,7 @@ interaction with [Git](http://en.wikipedia.org/wiki/Git_%28software%29), if you
 want to become more familiar with it consider reading through the freely
 available [git-scm book](http://git-scm.com/book).
 
-This also all revolves around the concept of the Pull Request on GitHub, so you
+This also all revolves around the concept of the Pull Request on GitHub, so
 read through their
 [documentation](https://help.github.com/articles/using-pull-requests) if you
 need further guidance.


### PR DESCRIPTION
Removed the word "you" from "so you read through their documentation". The sentence now reads "so read through their documentation".
