### PR TITLE
redirect api/doc/doc subdomains to https

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -126,15 +126,15 @@ http {
   server {
     listen 80;
     server_name doc.nodejs.org docs.nodejs.org;
-    rewrite ^/(v[0-9]+\.[0-9]+\.[0-9]+)(/?.*)$ http://nodejs.org/docs/$1$2 permanent;
-    rewrite /(.*)$ http://nodejs.org/docs/latest/$1 permanent;
+    rewrite ^/(v[0-9]+\.[0-9]+\.[0-9]+)(/?.*)$ https://nodejs.org/docs/$1$2 permanent;
+    rewrite /(.*)$ https://nodejs.org/docs/latest/$1 permanent;
   }
 
   server {
     listen 80;
     server_name api.nodejs.org;
-    rewrite ^/(v[0-9]+\.[0-9]+\.[0-9]+)(/?.*)$ http://nodejs.org/docs/$1/api$2 permanent;
-    rewrite /(.*)$ http://nodejs.org/docs/latest/api/$1 permanent;
+    rewrite ^/(v[0-9]+\.[0-9]+\.[0-9]+)(/?.*)$ https://nodejs.org/docs/$1/api$2 permanent;
+    rewrite /(.*)$ https://nodejs.org/docs/latest/api/$1 permanent;
   }
 
   server {


### PR DESCRIPTION
This is missing the blog subdomain as it returns a ssl error: https://github.com/joyent/node-website/issues/70

redirect
- http://api.nodejs.org
- http://doc.nodejs.org
- http://docs.nodejs.org

to their https pendants

tested locally with:

```
http://api.nodejs.dev
http://api.nodejs.dev/v0.10.11
http://doc.nodejs.dev/v0.10.3/api
http://docs.nodejs.dev/v0.10.3/api
```

using a modified `/etc/hosts`:

```
127.0.0.1       nodejs.dev
127.0.0.1       blog.nodejs.dev
127.0.0.1       doc.nodejs.dev
127.0.0.1       api.nodejs.dev
127.0.0.1       dist.nodejs.dev
127.0.0.1       docs.nodejs.dev
```
