### PR TITLE
add warning for gyp failures

### DIFF
--- a/doc/download/index.html
+++ b/doc/download/index.html
@@ -129,6 +129,11 @@
       Note: Python 2.6 or 2.7 is required to build from source tarballs.
     </p>
 
+    <p>
+      Note: if you experience errors when doing <code>npm install</code> containing 'gyp ERR!', try using 
+      <a href="//nodejs.org/dist/0.10.36/">node-v0.10</a>
+    </p>
+
     <h2 style="margin-top:1em" id=other-info>Other Info</h2>
     <ul>
       <li><a href="http://nodejs.org/dist/__VERSION__/SHASUMS.txt.asc">Shasums</a></li>


### PR DESCRIPTION
When upgrading minor versions packages using node-gyp often fail to
compile initially.  Until the community responds and packages are
updated, node-v0.12 will be unusable to some.  Most will miss
this notice, but hopefully it'll save a few headaches.

This is my minimum expectation of warning.  Ideally it would be
placed directly under "Current version: v0.12.0", and have a
light yellow background.

This warning is intended to be temporary, and be removed in a
few months.  It should then reappear when this page is upgraded
for node-v0.14.

Edit: I would just like to clarify that this is mainly targeted at [new users](http://stackoverflow.com/questions/28382954/npm-install-throws-error).  Many people start using node by reading tutorials that simply say to go to nodejs.org/download/.  These people don't know what gyp is or even that 0.12 was released recently.  
