### PR TITLE
Add core team meetings page

### DIFF
--- a/doc/about/core-team/index.json
+++ b/doc/about/core-team/index.json
@@ -1,1 +1,1 @@
-{ "template": "doc/about.html", "title": "Core Team" }
+{ "template": "doc/about/core-team/template.html", "title": "Core Team" }

--- a/doc/about/core-team/meetings/2014-12-10/minutes.md
+++ b/doc/about/core-team/meetings/2014-12-10/minutes.md
@@ -1,0 +1,59 @@
+# Minutes for the Node.js core team meeting of 12/10/2014
+
+A [video recording](https://bluejeans.com/s/7_j@/) of this meeting is also
+available.
+
+## Team announcements
+
+Colin Ihrig is promoted to apprentice. Chris Dickinson and Julien Gilli are
+promoted from apprentice to core team members.
+
+## Next releases
+
+### 0.10.34
+
+The next stable release, 0.10.34, is imminent and should be available in the
+next few days. The only issue remaining is that recently libuv added an entry
+to the public API (see https://github.com/libuv/libuv/commit/9da5fd443ebc2c56a
+7f5946f0a1e04801b370a33). Node will need to find a way to not cause any
+problems for users who link node with a dynamic shared libuv.
+
+### 0.11.15
+
+Nobody had any blocker for the next developement release, whose release is
+also scheduled to happen in the next few days. The priority is given to
+releasing 0.10.34 first though.
+
+### 0.12
+
+#### Potential V8 upgrade
+
+During the previous meeting, the possibility of upgrading V8 to a more recent
+release was discussed. While everyone agreed that upgrading V8 to a version
+that is closer to what the V8 team considers to be stable would benefit all
+users in terms of new features (e.g generators), several concerns were
+expressed:
+
+* It is not clear what impact it would have on binary modules.
+
+* Users would need to upgrade their toolchain, as V8 moved to C++11. It's not a
+problem for individual developers, as they can upgrade easily most of the
+time. However, it could be a problem for distributions (an example is CentOS),
+and people who followed the 0.11.x branch for a long time and don't expect
+such a change.
+
+Moreover, everyone agreed that performing this upgrade that late in the
+development process and so close to a new stable relase is risky.
+
+The consensus seems to be leaning towards not upgrading V8 again before 0.12,
+and instead having a smaller list of features and fixes for the next stable
+release, with a much shorter release time. One of the first thing that would
+be done in the next unstable branch (0.13) would be a V8 upgrade.
+
+## TODO for next meeting
+
+Next meeting is December 11th at 9:00AM PST.
+
+* Come up with a list of the following GitHub issues:
+  * Needed for 0.12.0.
+  * Needed 0.12.1.

--- a/doc/about/core-team/meetings/2014-12-16/minutes.md
+++ b/doc/about/core-team/meetings/2014-12-16/minutes.md
@@ -1,0 +1,143 @@
+# Minutes for the Node.js core team meeting of 12/16/2014
+
+## Participants
+
+* Chris Dickinson.
+* TJ Fontaine.
+* Julien Gilli.
+* Colin Ihrig.
+* Wyatt Preul.
+* James M Snell.
+
+## Upcoming releases
+
+### 0.10.34
+
+Work on releasing 0.10.34 had already started, and is scheduled to be done
+today (12/16/2014) or tomorrow (12/17/2014).
+
+### 0.10.35
+
+It is still not clear if and when a 0.10.35 version will be released, but
+Chris Dickinson already identified [one of his pull-requests](TODO: Chris,
+could you please provide the link to your PR about improving buffers'
+performance?) as a good candidate for inclusion in this release.
+
+### 0.11.15
+
+Work on releasing 0.11.15 has already started. TODO: do we want to fix all
+issues with --with-intl=small-icu before doing this release?
+
+### 0.12.1
+
+0.12.0 is not yet released, but some issues/PR can already be added to the
+0.12.1 milestone. Good candidates for the 0.12.1 milestone are things we know
+in the v0.12 branch are bugs but not blockers, and that we know are not API
+changes that would break backward compatibility.
+
+A good example is for instance the inclusion of the full ICU data in binary
+installers for OS X and Windows.
+
+## Node.js' Website
+
+Wyatt Preul and other contributors have been very active recently in
+integrating contributions to the Node.js' website that had been on hold for a
+while. The core team discussed some of the current contributions/issues as
+well as potential future improvements.
+
+### Security page
+
+One of these contributions is [the addition of a page dedicated to security
+related informations](https://github.com/joyent/node-website/pull/60). In
+order to make progress on that front, Wyatt needs the approval from the core
+team.
+
+### Future work on documentation
+
+In the future, ideally users would be able to choose the version of the API
+documentation they want to read. More general documentation (e.g tutorials,
+best practices, etc) would also be very welcome. However, the goal would be to
+not recommend any specific third party modules or application. A good example
+of some more general documentation would be an article on "How to use Node.js'
+http module efficiently?"
+
+The team agreed on updating the documentation as soon as possible. In
+practice, that means as soon as documentation PRs are landed. The Makefile
+included in Node.js' source repository should already make this easy.
+
+Regarding the merge of documentation changes, they should follow the same
+process as code changes. Documentation changes should be made in the oldest
+supported version that is affected, and merges should happen as soon as
+possible and should land in any version also affected by the change.
+
+### Discussions on the process to add a new page
+
+The participants agreed that before adding any new page to the Website, the
+core team should approve it by adding a comment in the associated pull-request
+page on GitHub.
+
+## Other dicussions
+
+### Development process
+
+There has been some discussions on how and when to land contributions in the
+source tree, and when to merge them into other branches. The team agreed on
+merging early and often, which hasn't necessarily been the case recently.
+
+Changes should be landed in the branch representing the oldest supported
+version affected by the change (v0.10 as of now). Merges should be done as
+soon as possible in branches representing any other version affected.
+
+The team also agreed to try to use GitHub milestones more. Three new
+milestones have been created: 0.11.16, 0.12.0 and 0.12.1. The team should make
+sure that any issue or PR that should be considered for these releases be
+added to the appropriate milestone.
+
+However, milestones on GitHub are quite limited. For instance, it is not
+possible to add an issue or a PR to more than one milestone. When this is
+needed, labels can be used to add the appriopriate information.
+
+### ICU support
+
+ICU will be enabled for as many platforms as possible (with `--with-intl=small-
+icu`, which includes only the English locale) in the 0.11.15 release. Steven R.
+Loomis and Julien Gilli are currently working on fixing the latest remaining
+issues. As of today, all builds and tests pass on all supported platforms, but
+some PRs need to be reviewed and landed.
+
+The 0.12.0 release will not be blocked by these issues. In the worse case,
+platforms for which ICU support is not working properly will be fixed in the
+0.12.1 release.
+
+Support for full ICU data (with many more locales) will be provided in a later
+0.12.x release (ideally 0.12.1). Note that this will not change the `Intl`
+API, so there's no need to worry about backward compatibility.
+
+### OpenSSL patches queue and handling dependencies
+
+Chris Dickinson started to work on a way to use a patches queue to handle
+Node.js' dependency on OpenSSL.
+
+Ideally, instead of writing its own gyp files to build OpenSSL, Node.js would
+apply custom patches from a patch queue and use gyp only to drive OpenSSL's
+original build process (e.g `./configure && make && make install`).
+
+TODO Chris Dickinson: Could you please  mention the only patch that needs to
+be submitted upstream for OpenSSL? I think you mentioned something like a
+"return" patch?
+
+Ideally, that approach would be generalized to as many dependencies as
+possible (e.g zlib).
+
+### Recent changes to mdb
+
+TJ Fontaine has done some very exciting progress on mdb. He added a new
+`::jsscope` command that allows users to examine the content of a given
+function's closure. (TODO: TJ, could you please correct any
+approximation/mistake and add any relevant info?).
+
+### Planning of next core team meetings
+
+Every Tuesday, Chris Dickinson will send and e-mail to team@nodejs.org to ask
+for things people want to discuss on the next core team meeting happening
+every Thursday.

--- a/doc/about/core-team/meetings/2014-12-18/minutes.md
+++ b/doc/about/core-team/meetings/2014-12-18/minutes.md
@@ -1,0 +1,75 @@
+# Minutes for the Node.js core team meeting of 12/18/2014
+
+## Participants
+
+* Chris Dickinson
+* TJ Fontaine
+* Julien Gilli
+* Colin Ihrig
+* Steven R. Loomis
+
+## Update on ICU
+
+### Build process
+
+The team agreed that the download of ICU's source code should be opt-in
+instead of the default. This would bring node's ICU support more in line with
+the build process of most other projects. This is not considered a a blocker
+for 0.11.15.
+
+### Tests
+
+Standard tests have already been run on all supported platforms with node
+built with --with-intl=small-icu, and no error has been found. However, there
+is currently just one ICU specific test (in `test/simple/test-intl.js`).
+
+Tests for the support of full ICU data shipped with binary packages have
+started. They  pass for the OS X installer. Support for shipping full ICU data
+needs to be implemented on Windows (in the MSI installer), SmartOS and Linux
+(in binary tarballs). However, this is not a priority for the 0.12.0 release.
+
+There is currently no test in the node code base to test full ICU support, all
+tests for full ICU support have been done manually so far.
+
+#### Packaging full ICU data
+
+The team agreed to store full ICU data in a separate file located relative to
+node's binary. It will be loaded by computing its location at runtime relative
+to Node.j's executable path. Steven noted that ICU supports a list of paths to
+load data from, which could help to supports platforms like Windows that do
+not put the node binary in a separate "bin" subdirectory.
+
+The participants also agreed to implement this at the C++ layer.
+
+## 0.10.34 release
+
+The 0.10.34 version released on 12/17/2014 has three different issues:
+
+* SSL/TLS connections to some servers, including amazon servers throw an
+exception because of an untrusted certificate. Participants agreed to fix this
+issue by putting 1024 bits length certificates back in the trusted
+certificates store.
+
+* A minor timer issue due to a typo in a fix for a memory leak.
+
+* A less minor timer issue due to a bug in the refactoring of `_unrefActive`
+done to improve performance.
+
+## Discussions around tools for developers of Node
+
+The participants discussed about various tools that could improve the workflow
+of contributors to Node.js' core.
+
+### A tool to apply pull requests
+
+This tool could be an equivalent of `curl PR.patch | git am - --signoff`, with
+additional features like:
+
+* Adding metadata from the GitHub PR.
+* Updating the AUTHORS file.
+
+### nodebug.me command line version
+
+Chris Dickinson recently released a command line interface to its great
+http://nodebug.me/ issues/PRs triaging tool.
+

--- a/doc/about/core-team/meetings/2015-01-15/minutes.md
+++ b/doc/about/core-team/meetings/2015-01-15/minutes.md
@@ -1,0 +1,46 @@
+# Minutes for the Node.js core team meeting of 01/15/2015
+
+## Participants
+
+* Timothy J Fontaine
+* Julien Gilli
+* Robert Kowalski
+
+## Topics
+
+### Website
+
+The only topic that was discussed during this meeting was the Node.js website.
+
+#### HTTPS access
+
+Robert suggested adding HTTPS access for Node.js' website. TJ mentioned that
+there is already a HTTPS endpoint on the website, but that clients (browsers,
+etc.) are not *redirected* by default from http to https, because doing so was
+breaking a lot of people (e.g nvm).
+
+Proposed solution by TJ: redirect everything by default to https except
+nodejs.org/dist.
+
+Robert proposed to setup a clone of the website with this change to be able to
+test it.
+
+#### Documentation versions
+
+Robert suggested a new feature for the documentation available on Node.js'
+website: accessing docs for different versions.
+
+Robert asked if regenerating the documentation for versions older than 0.10
+makes sense. TJ mentioned that we probably don't want to go back further than
+0.10. However, participants agreed that in the future, publishing older
+documentation could be fun and/or interesting.
+
+TJ suggested that documentation generation tools could be refactored and
+published as npm packages so that they can work standalone. That could make
+generating documentation for different versions easier.
+
+TJ also pointed out that a significant SEO effort went into making sure that
+the latest Node.js documentation shows up when searching for Node
+documentation, and that any change to the website's documentation should
+preserve that.
+

--- a/doc/about/core-team/meetings/2015-01-22/minutes.md
+++ b/doc/about/core-team/meetings/2015-01-22/minutes.md
@@ -1,0 +1,84 @@
+# Minutes for the Node.js core team meeting of 01/22/2015
+
+## Participants
+
+* Michael Dawson
+* Chris Dickinson
+* TJ Fontaine
+* Julien Gilli
+* Colin Ihrig
+* Robert Kowalski
+* Steven R Loomis
+* Trevor Norris
+
+## Minutes
+
+### Update on the state of 0.11.16
+
+#### Tool to update AUTHORS file
+
+The current tooling to update the AUTHORS and .mailmap file should be
+refactored to:
+- Order authors by name using a stable sort algorithm.
+- Update the .mailmap file with authors' email addresses.
+
+Julien has been assigned to this and work is in progress at
+https://github.com/joyent/node/pull/9088.
+
+Participants agreed that eventually the project should have more tooling to
+land changes from contributors and that these tools would also take care of
+updating authors files each time a contribution is integrated in the code
+repository.
+
+#### url.format/url.parse
+
+The only issue non-straightforward issue remaining in the 0.11.6 milestone is a
+[recent regression in
+`url.format`](https://github.com/joyent/node/issues/9070).
+
+Two discussions started, one that was about what can be done before v0.12.0 is
+released, and another one about what can be done post v0.12.0. Some
+participants mentioned that ultimately, the goal would probably be to conform
+to the whatwg spec and deprecate the current `url` module.
+
+All participants agreed that before v0.12.0 is released, `url.format` should
+throw on conflicting properties. Chris was assigned to this task.
+
+#### Target date
+
+The target date for releasing 0.11.16 is "as soon as possible". Being a
+development release, there's no constraint on which day of the week the
+release should be done.
+
+### Update on ICU (i18n) for 0.12.0
+
+Steven tested the English language support included in the v0.11.15 release.
+He mentioned that it seems to be working fine, but that he hadn't had the
+opportunity to test loading additional data.
+
+Robert, Steven and TJ also discussed updating the website to document how to
+load additional data.
+
+### Website / Documentation effort
+
+Robert and TJ discussed how to to factor out the documentation from the
+project. Robert also mentioned that he'd like to work with Chris on the
+website to integrate features/tools that are now available in io.js (for
+instance, comments in documentation).
+
+Robert also mentioned that he's going to check-in the website's configuration
+file in source control.
+
+### Node on Power processors
+
+Michael Dawson from IBM talked about Node.js on PowerPC processors. TJ and
+Michael agreed that the target for such a port would likely be 0.14.0. Michael
+mentioned that ideally the process of upstreaming changes to V8 would be done
+by that time. If not, there has been discussions recently between TJ and Chris
+on refactoring the dependencies management so that maintaining floating
+patches (also for other dependencies liek c-ares and OpenSSL) would be easier.
+
+### 0.10.36 release
+
+The 0.10.36 milestone is done, and the release is planned for today (Thursday
+January 22nd).

--- a/doc/about/core-team/meetings/2015-01-29/minutes.md
+++ b/doc/about/core-team/meetings/2015-01-29/minutes.md
@@ -1,0 +1,46 @@
+# Minutes for the Node.js core team meeting of 01/29/2015
+
+## Participants
+
+* Michal Dawson
+* TJ Fontaine
+* Colin Ihrig
+* Julien Gilli
+* Robert Kowalski
+* James Snell
+
+## Website
+
+Robert: Partially redirected http -> https for api docs and docs. Only blog
+page missing. Learning about SNI. Documentation generation tool: created a
+tests suite that runs some smoke tests. Hopes to get a PR for that next week.
+
+TJ: We have a wildcard cert for the blog, so using this cert might be easier
+than using SNI.
+
+## 0.11.16 release
+
+Colin: has two bug fixes not API breaking that could go in for 0.11.16.
+
+TJ: Would like to put https://github.com/joyent/node/pull/8966 in v0.10. Colin
+hasn't tried to rebase it on v0.10, but will do today.
+
+## Building dependencies
+
+James: Working on refactoring the way dependencies (deps/) are built.
+
+TJ: The build refactoring should target the master branch, and then might get
+backported to v0.12.
+
+## PRs/Issues in io.js
+
+TJ: When we see bugs in io.js that are also in Node.js, then please report
+these bugs.
+
+James: I'm going to go through the recent changes in io.js and will report
+issues/PRs.
+
+## PowerPC support
+
+Michael, James and TJ: Jenkins agents building and running tests for the Power
+platform will be hooked up asap.

--- a/doc/about/core-team/meetings/2015-02-05/minutes.md
+++ b/doc/about/core-team/meetings/2015-02-05/minutes.md
@@ -1,0 +1,62 @@
+# Minutes for the Node.js core team meeting of 02/05/2015
+
+## Participants
+
+* Michael Dawson
+* TJ Fontaine
+* Julien Gilli
+* Colin Ihrig
+* Trevor Norris
+* Wyatt Preul
+* James Snell
+
+## Discussions
+
+### 0.12.0 release
+
+Julien: Remaining issues to release 0.12.0 are in the 0.11.17 milestone on GitHub.
+Everyone agreed that there's no blocker for this release.
+
+TJ: will put a draft for blog post for release notes up and the rest of the team will review it.
+
+#### Native modules breakage
+
+TJ: some modules that don't use nan or other ways to build with V8 shipped by
+node v0.12.x will break. These modules will need to be fixed on a case by case
+basis.
+
+### Website
+
+Wyatt: security page published.
+
+### Post 0.12.0
+
+TJ: From now on, it would be nice if core team members would use
+https://github.com/joyent/git-apply-pr to land PRs/contributions. It's a work
+in progress, bug fixes/improvements are more than welcome!
+
+TJ: We may discuss what to integrate from the core team working group of the
+Node.js Advisory Board (https://github.com/joyent/nodejs-advisory-board)
+during the next core team call.
+
+### Testing downstream modules and applications
+
+Michael Dawson: need for higher level benchmarks (for upper layers like
+express, etc.).
+
+TJ: Some people have been working on downstream integration tests (for
+instance, Julien with test-node-apps)
+
+TJ: Downstream integration tests, downstream benchmarking desirable in the
+future.
+
+James: identify the top 120 most depended on modules, determine what core
+modules they use, and create a tests framework around that.
+
+Michael: Michael and James already have something simple that run tests for
+some npm modules.
+
+### Node summit
+
+TJ: Tentative meeting on Monday 2pm to 4pm: purely technical meeting about
+roadmap, not a meeting about governance.

--- a/doc/about/core-team/meetings/2015-02-09/minutes.md
+++ b/doc/about/core-team/meetings/2015-02-09/minutes.md
@@ -1,0 +1,224 @@
+# Minutes for the Node Summit technical roadmap meeting of 09/02/2015
+
+## Participants
+
+* Alexis Campailla
+* Michael Dawson
+* TJ Fontaine
+* Julien Gilli
+* Jacob Groundwater
+* Steven Loomis
+* Trevor Norris
+* Issac Roth
+* Todd Moore
+* Dan Shaw
+* James Snell
+* Erik Toth
+
+## TJ: Updating V8 versions
+
+Difference between communities. Important for IBM's regarding upstream power port.
+
+Michael Dawson: Regarding porting to power, upstreamed 2 out of the three
+parts. Started discussions on optimizations. Hoping to get this upstreamed
+this quarter. It's gonna be a little longer for the zSeries support.
+
+TJ: proposed solution: being able to run the V8 runtome as a dynamic library.
+Potential issues: modules and user land code might have to perform runtime tests to
+figure out if specific features in the JavaScript runtime are present.
+
+Dan Shaw: How to handle Node.js' JavaScript APIs using recent runtime's
+capabilities (promises) that are not present in all versions of V8?
+
+TJ: That's already a problem today, and this proposed solution doesn't
+eliminate this problem. Maybe use the "engines" properties in package.json
+for user land modules to express their requirements.
+
+Dan Shaw: Do we need a baseline for a minimum supported set of
+language/runtime level features?
+
+TJ: Having a specification of a fundamental base layer on the runtime side.
+
+Alexis Campailla: How to handle different versions of V8?
+
+TJ: my preference would be to use something like node-addon-layer as an
+abstraction layer.
+
+Alexis, TJ: that would become the blessed V8/JSruntime API for binary add-ons.
+
+TJ: C++ ABI has worked so far, but probably because we've been lucky. So C API
+makes more sense and would be more robust accross different platforms.
+
+Alexis Campailla: What about nan?
+
+TJ: nan is a header only C++ library, so it wouldn't solve the case of loading
+runtimes dynamically. However, as a lot of users of Node.js use nan, we might
+have to provide a double abstraction.
+
+Isaac Roth: All of that sounds good, but it puts a lot of burden on module
+authors.
+
+TJ: Bert mentioned previously that using NaCl could be interesting.
+
+## Issues with specing what a Node.js runtime baseline is
+
+Erik Toth: Paypal has problems with JavaScript, not with Node.js. EcmaScript
+standard is a bit nebulous, and so talking about a platform identified with an
+Ecma Script version is very confusing.
+
+James Snell: That's why we would need a baseline spec for what would be a
+compatible Node.js runtime.
+
+IBM: Specs will be unsufficient, we'll need tests also.
+
+TJ: Asynchronous code can be made easier to troubleshoot with using other
+mechanisms than promises, for instance vasync module, or other tooling.
+
+Dan Shaw: ES6 2015/2016 is coming way faster than I expected. Node.js should be
+a runtime where we can run untranspiled/untransformed code. Problems with
+JavaScript should be separated from problems that we have with Node.js itself.
+
+Issac Roth: Promises, generators, etc. will happen anyway, so we have to
+support that.
+
+Issac Roth: Promises is a core abstraction, and so promises are unavoidable.
+
+TJ: Problem of re-using code written for the browser which uses promises.
+
+Trevor: What is the point of the discussion?
+
+Trevor: The interface between the JavaScript layer and the native layer is a
+mess, cleaning that up will allow to build whatever type of interface to the
+code native layer.
+
+Trevor: You can't transition all asynchronous APIs to promises (e.g event
+emitters)
+
+Trevor: 1st priority should be to refactor some core layers to use lower level
+APIs to improve performance (e.g http should use tcp_wrap instead of
+lib/net.js).
+
+Trevor: Before supporting promises at the core layer, we'd have to do some
+simplification work.
+
+Trevor: Supporting loading different runtimes will make supporting existing
+(memory monitors, tracking GC events, etc.) tooling much more difficult.
+
+## Issac Roth: Internationalization
+
+Issac Roght: Ability to translate/localize error messages.
+
+James Snell: One of IBM's mandate is to be able to ship code localized for 70
+countries, otherwise needs to get exceptions.
+
+TJ: Also, concept of cleaning up error messages/objects related to i18n of error
+messages.
+
+## Dan Shaw: We talked about abstracting V8, what about libuv?
+
+TJ: libuv doesn't fit the same kind of niche as V8. However, an abstraction
+layer would be helpful.
+
+Dan Shaw: Concern of how and when Node.js will catch up with libuv?
+
+TJ: At some point in the release cycle, we have to close the gates and we
+can't integrate latest versions of dependencies.
+
+TJ: Carefully scoped roadmap and more frequent releases should allow us to integrate
+newer versions of dependencies often.
+
+Isaac Roth: It will be difficult to get broad agreement on a roadmap. Usually,
+open source projects work by integrating changes organically from contributors
+dependening on what they want to work on.
+
+TJ: Have the requirement of at any time, the tip of the development
+branch can be used as a release candidate.
+
+## Alexis Campailla: Work to build all PRs on every supported platforms.
+
+Alexis Campailla: I've been doing some work to be able to build/test code from
+any GitHub pull request.
+
+## Alexis Campailla: Funning benchmarks for Windows.
+
+Julien: Tracking benchmarks results accross every commit would be very useful
+to identify the causes of performance regressions.
+
+James Snell, Michael Dawson: IBM started to run benchmarks for downstream
+dependencies, and wants to do more of that.
+
+## TJ: cluster
+
+James: Cluster seems to be used only by 6 npm modules (grepped 'cluster'
+through 120 most used modules). However, these modules could (and probably)
+use pm2 or other abstraction on top of cluster.
+
+TJ: Cluster is mostly used internally by glue code.
+
+Alexis: Datagram socket not supported on Windows. There's a lot of room for
+improvement in the implementation.
+
+Isaac: Performance of the cluster module is not satisfying, made some
+comparison with nginx and cluster seems to be 3x slower. Could need a rewrite.
+
+Jacob: Lots of users who directly use cluster module, sometimes by just
+copy/pasting code from the doc. I would say cluster is used widely.
+
+TJ: Preference would have been to improve child_process and have userland
+modules implement clustering features.
+
+## James Snell: Crypto improvements
+
+James Snell : Better access to crypto hardware is needed.
+
+TJ: libressl came out with a very compelling C API that Node.js could use.
+
+## Julien Gilli: stricter APIs
+
+Julien Gilli: There are a lot of fragile APIs in Node.js. It makes these APIs
+hard to use correctly, and it is also very time consuming for contributors who
+help users troubleshoot issues related to misuses of APIs.
+
+Julien: Example of recent improvement was making net.Socket.setTimeout's API
+stricter.
+
+TJ: Differences between browser APIs strictness and Node.js API strictness.
+It's also a documentation effort and is related to better error messages.
+
+Erik Toth: Ecma has a formal type proposal that could be related.
+
+## Julien Gilli: lldb-v8
+
+Julien: lldb-v8 is a great tool that, if working more reliably with different
+versions of node, could help both users and the core team to investigate bugs.
+
+TJ: I believe IBM has another toolchain that they use.
+
+## Erik Toth: What's the plan with async_wrap?
+
+Dan Shaw: Gathering input from potential users currently.
+
+TJ: Some interesting output from the meeting in Vancouver last summer.
+
+Erik Toth: Lower level thing that we want to see where it goes.
+
+Jacob: Various needs for tracing, some fairly basic (intercepting what is
+logged by console.log), some much more advanced like inspecting V8 internals.
+Needs to move slowly to make sure these broad needs are satisfied.
+
+IBM: Performance is crucial.
+
+Isaac Roth: Had to constantly reimplement tracing solutions because of
+changing requirements from users. Maybe need to be very generic about this.
+
+TJ: My proposed solution was to inject calls to probes that are interpreted by
+platform-specific tracing frameworks (dtrace, ETW, etc.)
+
+Issac Roth: Building a more generic layer that other user land modules can
+build upon.
+
+## Closing comments and action items
+
+James Snell: Need to prioritize things.
+
+TJ: Post ideas for roadmap somewhere where people can comment.

--- a/doc/about/core-team/meetings/2015-02-19/minutes.md
+++ b/doc/about/core-team/meetings/2015-02-19/minutes.md
@@ -1,0 +1,189 @@
+# Minutes for the Node.js core team meeting of 02/19/2015
+
+## Participants
+
+### Present
+
+* Alexis Campailla
+* Michael Dawson
+* TJ Fontaine
+* Julien Gilli
+* Colin Ihrig
+* Steven Loomis
+* Bradley Meck
+* Trevor Norris
+* Wyatt Preul
+
+### Regrets
+* James Snell
+  * Working on:
+    * Enabling openssl tests during the build similar to how I enabled the v8 tests.
+    * Resource and message bundle support.
+
+* Robert Kowalski
+  * Progress:
+    * I fixed the bad merge for https://github.com/joyent/node-documentation-
+     generator and will continue to work on it, next items are .markdown
+     support and sending a PR to node and node-website to make use of the
+     module.
+
+    * It is [not possible any more to accidentally deploy an outdated version of
+     the website](https://github.com/joyent/node-website/commit/dc1ab6f2037a9005d7fc44e73001bf9067e25d5b).
+
+  * Blocked by:
+    * I'm still waiting for a fixed SSl Cert for https://blog.nodejs.org/ to
+    continue with https://github.com/joyent/node-website/issues/68.
+
+## Current state of v0.12.0
+
+### V8 issues
+
+Julien: A lot of issues related to V8 came up recently after v0.12.0 was
+released. I believe Trevor is working on most of them right now.
+
+Trevor: Yes, I'm currently investigating.
+
+#### V8 max_old_space issue
+
+See https://github.com/joyent/node/pull/9200#issuecomment-75001656.
+
+TJ: We'll float the patch as it's pretty uncontroversial.
+
+#### VM module
+
+See https://github.com/joyent/node/issues/9084.
+
+TJ: would like to reboot the VM module. Will do a writeup in
+https://github.com/joyent/node/issues/9084. Who would like to work on
+implementing the proposed enhancements?
+
+Colin: I would like to work on this.
+
+TJ: alright!
+
+#### let issue
+
+See https://github.com/joyent/node/issues/9113.
+
+TJ: This one should be able to be debugged with only d8 to identify if and
+what version of V8 introduced the bug.
+
+### node::Makecallback issue
+
+See https://github.com/joyent/node/issues/9245.
+
+Trevor: there's a case with some developers add-on where calling
+`MakeCallback` processes next tick callbacks. I'm working on a fix that would
+make calling MakeCallback safe in every case.
+
+### Security issue with shared OpenSSL
+
+See https://github.com/iojs/io.js/pull/800.
+
+### --abort-on-uncaught-exception and domains
+
+Colin: abort on uncaught exception fix hasn't been forward ported to 0.12.0,
+so that prevents us from upgrading to 0.12.0.
+
+Julien: There's an issue in the 0.12.1 milestone that tracks this. See
+https://github.com/joyent/node/issues/8877.
+
+### Installer on Windows not updating PATH
+
+See https://github.com/joyent/node/issues/4356.
+
+Alexis: issue with installer on Windows. Julien: fixed in io.js. Alexis: I
+will take care of this.
+
+### TCP_NODELAY issue
+
+See https://github.com/joyent/node/issues/9235.
+
+Michael Dawson: I have a candidate for a patch, would like to get feedback on that.
+
+### test-http-destroyed-socket-write2.js failing on AIX
+
+See https://github.com/joyent/node/issues/9234.
+
+Michael Dawson: I also have a patch for that, feedback wanted.
+
+## Website
+
+Use tracing documentation as starting point for the general documentation.
+
+## i18n
+
+TJ: what's the status on the bug with data customiser.
+
+Steven: thought it was an endianness issue. Updated the wiki to warn users.
+
+Steven: want to make full data available. Currently testing his solution.
+
+Bradley Meck, TJ and Steven Loomis will discuss bundles and resources today.
+
+## Issues triaging and general workflow
+
+Julien: I submitted a proposal to improve our workflow here:
+https://gist.github.com/misterdjules/50d78ed4b0c5a156edd1.
+
+Steven: It would be nice to know what's the focus on a release, so that we
+know what issues to put in the next milestones.
+
+Steven: Having the meeting to be a go/no-go meeting would help in being more
+efficient in this.
+
+Alexis: Doing triaging during weekly meetings would also be beneficial.
+
+TJ: call tomorrow where everyone comes up with a list of priorities for next
+milestone.
+
+TJ: call tomorrow to discuss the proposal sent by Julien.
+
+## libuv upgrade
+
+See https://github.com/joyent/node/pull/9179.
+
+TJ: Caveats in the GitHub issue are the only concerns that I have. enum/int
+ABI issue, not sure if it's an actual issue or not. Would like to get more
+feedback from more knowledgeable C/C++ users. Concerned by some of the
+behavior changes in libuv.
+
+Alexis: Users can use type casting if they have issues with the sizeof(enum)
+vs sizeof(int).
+
+TJ: also, probably doesn't affect a lot of packages since it affects only the
+`uv_tty` API.
+
+Julien: Failures on Windows.
+
+Alexis: I can help to look into that.
+
+## Team organization updates
+
+TJ: I would like to propose that Colin move from apprentice to core team
+member, and that Michael and Steven be appointed as apprenticies.
+
+## Publication of minutes
+
+TJ: we want to publish every meeting's minutes on the website.
+
+## Testing
+
+Michael Dawson: what tests should be run on a regular basis by any
+implementation?
+
+TJ: would like to have make test run as many tests suite as possible. At least
+we can make it run simple, message, gc and internet today.
+
+Michael Dawson: When do pummel, internet and other tests are run?
+
+TJ: Historically, we've run them when building nightlies for instance. Some
+pummel tests take a long time to run on virtualized windows environments.
+
+TJ, Michael Dawson: would like to have a mechanism to have platform specific
+tests.
+
+## Next core team meeting
+
+Thursday February 26th 2015.
+

--- a/doc/about/core-team/meetings/index.json
+++ b/doc/about/core-team/meetings/index.json
@@ -1,0 +1,1 @@
+{ "template": "doc/about/core-team/template.html", "title": "Core team meetings minutes" }

--- a/doc/about/core-team/meetings/index.md
+++ b/doc/about/core-team/meetings/index.md
@@ -1,0 +1,20 @@
+# Core team meetings
+
+* 2015-02-19
+  - [Minutes](2015-02-19/minutes.html)
+* 2015-02-09 (Node Summit technical roadmap)
+  - [Minutes](2015-02-09/minutes.html)
+* 2015-02-05
+  - [Minutes](2015-02-05/minutes.html)
+* 2015-01-29
+  - [Minutes](2015-01-29/minutes.html)
+* 2015-01-22
+  - [Minutes](2015-01-22/minutes.html)
+* 2015-01-15
+  - [Minutes](2015-01-15/minutes.html)
+* 2014-12-18
+  - [Minutes](2014-12-18/minutes.html)
+* 2014-12-16
+  - [Minutes](2014-12-16/minutes.html)
+* 2014-12-10
+  - [Minutes](2014-12-10/minutes.html)

--- a/doc/about/core-team/template.html
+++ b/doc/about/core-team/template.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <link type="image/x-icon" rel="icon" href="../favicon.ico">
+    <link type="image/x-icon" rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="/pipe.css">
+    <link rel="stylesheet" href="/sh_vim-dark.css">
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script type="text/javascript" src="//use.typekit.net/mse5tqx.js"></script>
+    <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
+    <link rel="alternate"
+          type="application/rss+xml"
+          title="node blog"
+          href="http://feeds.feedburner.com/nodejs/123123123">
+    <title>__TITLE__ | Node.js</title>
+  </head>
+
+  <body class="int alt" id="docs">
+    <div id="nav">
+      <img id="logo" src="/images/logo.svg" alt="node.js">
+      <ul>
+        <li><a href="/">Home</a></li>
+        <li><a href="/download/">Downloads</a></li>
+        <li><a href="/documentation/">Docs</a></li>
+        <li><a href="/community/">Community</a></li>
+        <li><a href="/about/">About</a></li>
+        <li><a href="http://jobs.nodejs.org">Jobs</a></li>
+        <li><a href="http://blog.nodejs.org">Blog</a></li>
+      </ul>
+    </div>
+
+    <div id="content-wrap">
+    <div id="content" class="clearfix">
+      <div id="column2" class="interior">
+        <!--<img src="/images/logo-light.svg" alt="node.js" width="170">-->
+        <ul class="docs-nav">
+          <li><a href="/about/">About Node.js</a></li>
+          <li><a href="/about/organization/">Organization</a></li>
+          <li><a href="/about/core-team/">Core Team</a></li>
+          <li>&nbsp;&nbsp;&nbsp; - <a href="/about/core-team/meetings/">Meetings</a></li>
+          <li><a href="/about/resources/">Resources</a></li>
+          <li><a href="/about/advisory-board/">Advisory Board</a></li>
+          <li><a href="/about/security/">Security</a></li>
+        </ul>
+      </div>
+      <div id="column1" class="interior">
+        <div id="toc">
+          <h2>Table of Contents</h2>
+          __TOC__
+        </div>
+        __CONTENT__
+      </div>
+    </div>
+    </div>
+
+    <div id="footer">
+      <div class="foot-1">
+        <a href="http://www.joyent.com"><h5>The Node.js Project is Sponsored by</h5>
+        <img src="/images/joyent-footer.svg" width="200">
+        <p class="tag">Production Node +<br>High Performance Infrastructure</p></a>
+        <a href="https://my.joyent.com/landing/signup/701800000015696" class="button getstarted">Get Started</a>
+      </div>
+      <div class="foot-2">
+        <div class="foot-nav">
+          <ul>
+            <li><a href="http://nodejs.org/download/">Downloads</a></li>
+          </ul>
+          <ul>
+            <li><a href="http://nodejs.org/documentation/">Documentation</a></li>
+            <li><a href="http://nodejs.org/api/">API Docs</a></li>
+            <li><a href="http://nodejs.org/documentation/tutorials/">Tutorials</a></li>
+            <li><a href="http://nodejs.org/documentation/localization/">Localization</a></li>
+          </ul>
+          <ul>
+            <li><a href="http://nodejs.org/community/">Community</a></li>
+            <li><a href="https://github.com/joyent/node/issues">Github Issues</a></li>
+            <li><a href="http://groups.google.com/group/nodejs">Mailing List</a></li>
+            <li><a href="http://webchat.freenode.net/?channels=node.js">IRC</a></li>
+            <li><a href="https://twitter.com/nodejs">Twitter</a></li>
+          </ul>
+          <ul>
+            <li><a href="http://nodejs.org/about/">About</a></li>
+            <li><a href="http://nodejs.org/about/organization/">Organization</a></li>
+            <li><a href="http://nodejs.org/about/core-team/">Core Team</a></li>
+            <li><a href="http://nodejs.org/about/resources/">Resources</a></li>
+          </ul>
+          <ul>
+            <li><a href="http://blog.nodejs.org">Blog</a></li>
+          </ul>
+        </div>
+        <p class="copyright">Copyright 2015 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/images/trademark-policy.pdf">trademark</a> of Joyent, Inc. <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">View license</a>.</p>
+      </div>
+    </div>
+
+    <script src="/sh_main.js"></script>
+    <script src="/sh_javascript.min.js"></script>
+    <script>highlight(undefined, undefined, 'pre');</script>
+
+    <script>
+      $(document).ready(function() {
+        $('#nav a[href^="/' + location.pathname.split("/")[1] + '"]').parent().closest('li').addClass('active');
+        $('.docs-nav a').each(function() {
+          if ($(this).attr("href") == window.location.pathname) {
+            $(this).parent().closest('li').addClass('active');
+          }
+        });
+      });
+    </script>
+    <script src="/tracking.js"></script>
+    <script src="/main.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
This adds a "meetings" subsection to the "core team" section in the "About" page.

Do we currently have a way to avoid duplicating the whole `template.html` file in `doc/about/core-team/template.html` and instead just specify the link to the "meetings" page?

Also, the Node Summit technical roadmap meeting is not in this PR, I'll send it to all attendees so that they can review it first.
