### PR TITLE
nginx: redirect * to https, except /dist & *.json

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -23,11 +23,6 @@ http {
     listen 80;
     server_name  nodejs.org 8.12.44.238 www.nodejs.org;
 
-    ### Re-enable after people update nvm and travis-ci updates?
-    #   location / {
-    #     rewrite ^ https://nodejs.org$request_uri permanent;
-    #   }
-
     access_log  /var/log/nginx/nodejs.access_log main;
     error_log  /var/log/nginx/nodejs.error_log info;
 
@@ -47,6 +42,12 @@ http {
 
     location /documentation/ {
       rewrite ^/documentation/api(.*)$ /api$1 permanent;
+    }
+
+    # don't redirect dist to https as it breaks nvm/travis-ci
+    # probably the same is true for json
+    location ~ ^/(?!(dist/|dist$|\.json$)) {
+      rewrite ^ https://nodejs.org$request_uri permanent;
     }
 
     root /home/node/web/nodejs.org;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -19,28 +19,6 @@ http {
   keepalive_timeout 60;
   server_tokens off;
 
-  # gzip on;
-  # gzip_http_version 1.0;
-  # gzip_comp_level 2;
-  # gzip_proxied any;
-  # gzip_types text/plain text/html text/css application/x-javascript text/xml application/xml application/xml+rss text/javascript;
-
-  # upstream chat {
-  #   server localhost:7000;
-  # }
-
-  # upstream buildbot {
-  #   server localhost:8010;
-  # }
-
-  # upstream webircd {
-  #   server localhost:10001;
-  # }
-
-  # upstream modules {
-  #   server localhost:15443;
-  # }
-
   server {
     listen 80;
     server_name  nodejs.org 8.12.44.238 www.nodejs.org;


### PR DESCRIPTION
redirect everything on http://nodejs.org to their https
counterparts, except dist and *.json

tested using modified /etc/hosts:

```
curl -v http://nodejs.dev/dist/
curl -v http://nodejs.dev/dist
curl -v http://nodejs.dev/distribution
curl -v http://nodejs.dev/foobar
curl -v http://nodejs.dev/foobar.json
curl -v http://nodejs.dev/dist/123
curl -v http://nodejs.dev/foobar/lala.json
```

part of #68
