### PR TITLE
footer: link license on master

### DIFF
--- a/doc/about.html
+++ b/doc/about.html
@@ -84,7 +84,7 @@
             <li><a href="http://blog.nodejs.org">Blog</a></li>
           </ul>
         </div>
-        <p class="copyright">Copyright 2015 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/images/trademark-policy.pdf">trademark</a> of Joyent, Inc. <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">View license</a>.</p>
+        <p class="copyright">Copyright 2015 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/images/trademark-policy.pdf">trademark</a> of Joyent, Inc. <a href="https://raw.github.com/joyent/node/master/LICENSE">View license</a>.</p>
       </div>
     </div>
 

--- a/doc/about/advisory-board/template.html
+++ b/doc/about/advisory-board/template.html
@@ -90,7 +90,7 @@
             <li><a href="http://blog.nodejs.org">Blog</a></li>
           </ul>
         </div>
-        <p class="copyright">Copyright 2015 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/images/trademark-policy.pdf">trademark</a> of Joyent, Inc. <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">View license</a>.</p>
+        <p class="copyright">Copyright 2015 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/images/trademark-policy.pdf">trademark</a> of Joyent, Inc. <a href="https://raw.github.com/joyent/node/master/LICENSE">View license</a>.</p>
       </div>
     </div>
 

--- a/doc/about/core-team/template.html
+++ b/doc/about/core-team/template.html
@@ -89,7 +89,7 @@
             <li><a href="http://blog.nodejs.org">Blog</a></li>
           </ul>
         </div>
-        <p class="copyright">Copyright 2015 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/images/trademark-policy.pdf">trademark</a> of Joyent, Inc. <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">View license</a>.</p>
+        <p class="copyright">Copyright 2015 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/images/trademark-policy.pdf">trademark</a> of Joyent, Inc. <a href="https://raw.github.com/joyent/node/master/LICENSE">View license</a>.</p>
       </div>
     </div>
 

--- a/doc/blog.html
+++ b/doc/blog.html
@@ -171,7 +171,7 @@
           <li><a href="http://blog.nodejs.org">Blog</a></li>
         </ul>
       </div>
-      <p class="copyright">Copyright 2015 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/images/trademark-policy.pdf">trademark</a> of Joyent, Inc. <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">View license</a>.</p>
+      <p class="copyright">Copyright 2015 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/images/trademark-policy.pdf">trademark</a> of Joyent, Inc. <a href="https://raw.github.com/joyent/node/master/LICENSE">View license</a>.</p>
     </div>
   </div>
 

--- a/doc/contributing.html
+++ b/doc/contributing.html
@@ -76,7 +76,7 @@
             <li><a href="http://blog.nodejs.org">Blog</a></li>
           </ul>
         </div>
-        <p class="copyright">Copyright 2015 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/images/trademark-policy.pdf">trademark</a> of Joyent, Inc. <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">View license</a>.</p>
+        <p class="copyright">Copyright 2015 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/images/trademark-policy.pdf">trademark</a> of Joyent, Inc. <a href="https://raw.github.com/joyent/node/master/LICENSE">View license</a>.</p>
       </div>
     </div>
 

--- a/doc/docs.html
+++ b/doc/docs.html
@@ -83,7 +83,7 @@
             <li><a href="http://blog.nodejs.org">Blog</a></li>
           </ul>
         </div>
-        <p class="copyright">Copyright 2015 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/images/trademark-policy.pdf">trademark</a> of Joyent, Inc. <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">View license</a>.</p>
+        <p class="copyright">Copyright 2015 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/images/trademark-policy.pdf">trademark</a> of Joyent, Inc. <a href="https://raw.github.com/joyent/node/master/LICENSE">View license</a>.</p>
       </div>
     </div>
 

--- a/doc/download/index.html
+++ b/doc/download/index.html
@@ -150,7 +150,7 @@
       Node.js is released under the MIT
       license, and bundles other liberally licensed OSS components.
     <a
-      href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">Download the license</a></p>
+      href="https://raw.github.com/joyent/node/master/LICENSE">Download the license</a></p>
   </div>
 </div>
 </div>
@@ -189,7 +189,7 @@
         <li><a href="http://blog.nodejs.org">Blog</a></li>
       </ul>
     </div>
-    <p class="copyright">Copyright 2015 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/images/trademark-policy.pdf">trademark</a> of Joyent, Inc. <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">View license</a>.</p>
+    <p class="copyright">Copyright 2015 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/images/trademark-policy.pdf">trademark</a> of Joyent, Inc. <a href="https://raw.github.com/joyent/node/master/LICENSE">View license</a>.</p>
   </div>
   </div>
 </div>

--- a/doc/index.html
+++ b/doc/index.html
@@ -127,7 +127,7 @@ server.listen(1337, '127.0.0.1');</pre>
             <li><a href="http://blog.nodejs.org">Blog</a></li>
           </ul>
         </div>
-        <p class="copyright">Copyright 2015 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/images/trademark-policy.pdf">trademark</a> of Joyent, Inc. <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">View license</a>.</p>
+        <p class="copyright">Copyright 2015 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/images/trademark-policy.pdf">trademark</a> of Joyent, Inc. <a href="https://raw.github.com/joyent/node/master/LICENSE">View license</a>.</p>
       </div>
     </div>
 

--- a/doc/template.html
+++ b/doc/template.html
@@ -67,7 +67,7 @@
             <li><a href="http://twitter.com/nodejs" class="twitter">@nodejs</a></li>
         </ul>
 
-        <p class="copyright">Copyright 2015 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/images/trademark-policy.pdf">trademark</a> of Joyent, Inc. <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">View license</a>.</p>
+        <p class="copyright">Copyright 2015 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/images/trademark-policy.pdf">trademark</a> of Joyent, Inc. <a href="https://raw.github.com/joyent/node/master/LICENSE">View license</a>.</p>
     </div>
 
   <script src="../sh_main.js"></script>

--- a/doc/website.html
+++ b/doc/website.html
@@ -73,7 +73,7 @@
             <li><a href="http://blog.nodejs.org">Blog</a></li>
           </ul>
         </div>
-        <p class="copyright">Copyright 2015 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/images/trademark-policy.pdf">trademark</a> of Joyent, Inc. <a href="https://raw.github.com/joyent/node/__VERSION__/LICENSE">View license</a>.</p>
+        <p class="copyright">Copyright 2015 <a href="http://joyent.com/">Joyent, Inc</a>, Node.js is a <a href="/images/trademark-policy.pdf">trademark</a> of Joyent, Inc. <a href="https://raw.github.com/joyent/node/master/LICENSE">View license</a>.</p>
       </div>
     </div>
 


### PR DESCRIPTION
The current website links to the license of the version branch
of node which was used to create the website.

Currently we have at least two different links deployed in
production: in the footer of `https://nodejs.org/community/` the
link to the licene points to
`https://raw.github.com/joyent/node/v0.10.36/LICENSE` and the link
on `https://nodejs.org/about/core-team/meetings/` points to
`https://raw.github.com/joyent/node/v0.10.37/LICENSE`.

This leads to the following problem:

it is quite hard to find out what is deployed in production vs.
what changes are on my local branch. Additionally, not the latest
version of the license file is linked and we even have different
versions linked in production. For the website the link should
always point to master (but for version specific api docs, to the
version that the api docs show)
