### PR TITLE
Adding recent blog posts to Foundation list

### DIFF
--- a/doc/foundation/blog.md
+++ b/doc/foundation/blog.md
@@ -1,5 +1,7 @@
 # Blog
 
+- [Node.js and io.js leaders are building an open, neutral Node.js Foundation to support the future of the platform](http://blog.nodejs.org/2015/05/15/node-leaders-are-building-an-open-foundation/)
+- [The Node.js Foundation benefits all](http://blog.nodejs.org/2015/05/15/the-nodejs-foundation-benefits-all/)
 - [Node.js and io.js looking forward to reconciliation](https://github.com/iojs/io.js/issues/1664)
 - [Joyent CEO Scott Hammond looks forward to Node.js Foundation](https://www.joyent.com/blog/transitions)
 - [Node.js core contributor TJ Fontaine steps down, cheers the Node.js Foundation on](http://blog.nodejs.org/2015/05/08/next-chapter/)


### PR DESCRIPTION
Updated blog list with recent posts:
- [Node.js and io.js leaders are building an open, neutral Node.js Foundation to support the future of the platform](http://blog.nodejs.org/2015/05/15/node-leaders-are-building-an-open-foundation/)
- [The Node.js Foundation benefits all](http://blog.nodejs.org/2015/05/15/the-nodejs-foundation-benefits-all/)

/cc @misterdjules 
