### PR TITLE
Fix relative links

### DIFF
--- a/doc/about.html
+++ b/doc/about.html
@@ -76,9 +76,9 @@
             <li><a href="http://nodejs.org/contribute/becoming_collaborator.html">Becoming a collaborator</a></li>
           </ul>
           <ul>
-            <li><a href="/foundation/">Foundation</a></li>
-            <li><a href="/foundation/members.html">Members</a></li>
-            <li><a href="/foundation/blog.html">Blog</a></li>
+            <li><a href="http://nodejs.org/foundation/">Foundation</a></li>
+            <li><a href="http://nodejs.org/foundation/members.html">Members</a></li>
+            <li><a href="http://nodejs.org/foundation/blog.html">Blog</a></li>
           </ul>
           <ul>
             <li><a href="http://nodejs.org/community/">Community</a></li>
@@ -90,7 +90,7 @@
           <ul>
             <li><a href="http://nodejs.org/about/">About</a></li>
             <li><a href="http://nodejs.org/about/organization/">Organization</a></li>
-            <li><a href="/about/releases/">Releases</a></li>
+            <li><a href="http://nodejs.org/about/releases/">Releases</a></li>
             <li><a href="http://nodejs.org/about/resources/">Resources</a></li>
           </ul>
           <ul>

--- a/doc/blog.html
+++ b/doc/blog.html
@@ -22,8 +22,8 @@
       <li><a href="http://nodejs.org/">Home</a></li>
       <li><a href="http://nodejs.org/download/">Downloads</a></li>
       <li><a href="http://nodejs.org/documentation/">Docs</a></li>
-      <li><a href="/contribute/">Contribute</a></li>
-      <li><a href="/foundation/">Foundation</a></li>
+      <li><a href="http://nodejs.org/contribute/">Contribute</a></li>
+      <li><a href="http://nodejs.org/foundation/">Foundation</a></li>
       <li><a href="http://nodejs.org/community/">Community</a></li>
       <li><a href="http://nodejs.org/about/">About</a></li>
       <li><a href="http://jobs.nodejs.org">Jobs</a></li>
@@ -159,13 +159,13 @@
         <ul>
           <li><a href="http://nodejs.org/contribute/">Contribute</a></li>
           <li><a href="http://nodejs.org/contribute/code_contributions/">Code contributions</a></li>
-          <li><a href="/contribute/accepting_contributions.html">Accepting contributions</a></li>
+          <li><a href="http://nodejs.org/contribute/accepting_contributions.html">Accepting contributions</a></li>
           <li><a href="http://nodejs.org/contribute/becoming_collaborator.html">Becoming a collaborator</a></li>
         </ul>
         <ul>
-          <li><a href="/foundation/">Foundation</a></li>
-          <li><a href="/foundation/members.html">Members</a></li>
-          <li><a href="/foundation/blog.html">Blog</a></li>
+          <li><a href="http://nodejs.org/foundation/">Foundation</a></li>
+          <li><a href="http://nodejs.org/foundation/members.html">Members</a></li>
+          <li><a href="http://nodejs.org/foundation/blog.html">Blog</a></li>
         </ul>
         <ul>
           <li><a href="http://nodejs.org/community/">Community</a></li>
@@ -177,7 +177,7 @@
         <ul>
           <li><a href="http://nodejs.org/about/">About</a></li>
           <li><a href="http://nodejs.org/about/organization/">Organization</a></li>
-          <li><a href="/about/releases/">Releases</a></li>
+          <li><a href="http://nodejs.org/about/releases/">Releases</a></li>
           <li><a href="http://nodejs.org/about/resources/">Resources</a></li>
         </ul>
         <ul>

--- a/doc/code_contributions.html
+++ b/doc/code_contributions.html
@@ -75,9 +75,9 @@
             <li><a href="http://nodejs.org/contribute/becoming_collaborator.html">Becoming a collaborator</a></li>
           </ul>
           <ul>
-            <li><a href="/foundation/">Foundation</a></li>
-            <li><a href="/foundation/members.html">Members</a></li>
-            <li><a href="/foundation/blog.html">Blog</a></li>
+            <li><a href="http://nodejs.org/foundation/">Foundation</a></li>
+            <li><a href="http://nodejs.org/foundation/members.html">Members</a></li>
+            <li><a href="http://nodejs.org/foundation/blog.html">Blog</a></li>
           </ul>
           <ul>
             <li><a href="http://nodejs.org/community/">Community</a></li>
@@ -89,7 +89,7 @@
           <ul>
             <li><a href="http://nodejs.org/about/">About</a></li>
             <li><a href="http://nodejs.org/about/organization/">Organization</a></li>
-            <li><a href="/about/releases/">Releases</a></li>
+            <li><a href="http://nodejs.org/about/releases/">Releases</a></li>
             <li><a href="http://nodejs.org/about/resources/">Resources</a></li>
           </ul>
           <ul>

--- a/doc/community.html
+++ b/doc/community.html
@@ -68,9 +68,9 @@
             <li><a href="http://nodejs.org/contribute/becoming_collaborator.html">Becoming a collaborator</a></li>
           </ul>
           <ul>
-            <li><a href="/foundation/">Foundation</a></li>
-            <li><a href="/foundation/members.html">Members</a></li>
-            <li><a href="/foundation/blog.html">Blog</a></li>
+            <li><a href="http://nodejs.org/foundation/">Foundation</a></li>
+            <li><a href="http://nodejs.org/foundation/members.html">Members</a></li>
+            <li><a href="http://nodejs.org/foundation/blog.html">Blog</a></li>
           </ul>
           <ul>
             <li><a href="http://nodejs.org/community/">Community</a></li>
@@ -82,7 +82,7 @@
           <ul>
             <li><a href="http://nodejs.org/about/">About</a></li>
             <li><a href="http://nodejs.org/about/organization/">Organization</a></li>
-            <li><a href="/about/releases/">Releases</a></li>
+            <li><a href="http://nodejs.org/about/releases/">Releases</a></li>
             <li><a href="http://nodejs.org/about/resources/">Resources</a></li>
           </ul>
           <ul>

--- a/doc/contribute.html
+++ b/doc/contribute.html
@@ -70,13 +70,13 @@
           <ul>
             <li><a href="http://nodejs.org/contribute/">Contribute</a></li>
             <li><a href="http://nodejs.org/contribute/code_contributions/">Code contributions</a></li>
-            <li><a href="/contribute/accepting_contributions.html">Accepting contributions</a></li>
+            <li><a href="http://nodejs.org/contribute/accepting_contributions.html">Accepting contributions</a></li>
             <li><a href="http://nodejs.org/contribute/becoming_collaborator.html">Becoming a collaborator</a></li>
           </ul>
           <ul>
-            <li><a href="/foundation/">Foundation</a></li>
-            <li><a href="/foundation/members.html">Members</a></li>
-            <li><a href="/foundation/blog.html">Blog</a></li>
+            <li><a href="http://nodejs.org/foundation/">Foundation</a></li>
+            <li><a href="http://nodejs.org/foundation/members.html">Members</a></li>
+            <li><a href="http://nodejs.org/foundation/blog.html">Blog</a></li>
           </ul>
           <ul>
             <li><a href="http://nodejs.org/community/">Community</a></li>
@@ -88,7 +88,7 @@
           <ul>
             <li><a href="http://nodejs.org/about/">About</a></li>
             <li><a href="http://nodejs.org/about/organization/">Organization</a></li>
-            <li><a href="/about/releases/">Releases</a></li>
+            <li><a href="http://nodejs.org/about/releases/">Releases</a></li>
             <li><a href="http://nodejs.org/about/resources/">Resources</a></li>
           </ul>
           <ul>

--- a/doc/docs.html
+++ b/doc/docs.html
@@ -70,13 +70,13 @@
           <ul>
             <li><a href="http://nodejs.org/contribute/">Contribute</a></li>
             <li><a href="http://nodejs.org/contribute/code_contributions/">Code contributions</a></li>
-            <li><a href="/contribute/accepting_contributions.html">Accepting contributions</a></li>
+            <li><a href="http://nodejs.org/contribute/accepting_contributions.html">Accepting contributions</a></li>
             <li><a href="http://nodejs.org/contribute/becoming_collaborator.html">Becoming a collaborator</a></li>
           </ul>
             <ul>
-            <li><a href="/foundation/">Foundation</a></li>
-            <li><a href="/foundation/members.html">Members</a></li>
-            <li><a href="/foundation/blog.html">Blog</a></li>
+            <li><a href="http://nodejs.org/foundation/">Foundation</a></li>
+            <li><a href="http://nodejs.org/foundation/members.html">Members</a></li>
+            <li><a href="http://nodejs.org/foundation/blog.html">Blog</a></li>
           </ul>
           <ul>
             <li><a href="http://nodejs.org/community/">Community</a></li>
@@ -88,7 +88,7 @@
           <ul>
             <li><a href="http://nodejs.org/about/">About</a></li>
             <li><a href="http://nodejs.org/about/organization/">Organization</a></li>
-            <li><a href="/about/releases/">Releases</a></li>
+            <li><a href="http://nodejs.org/about/releases/">Releases</a></li>
             <li><a href="http://nodejs.org/about/resources/">Resources</a></li>
           </ul>
           <ul>

--- a/doc/foundation.html
+++ b/doc/foundation.html
@@ -75,9 +75,9 @@
             <li><a href="http://nodejs.org/contribute/becoming_collaborator.html">Becoming a collaborator</a></li>
           </ul>
             <ul>
-            <li><a href="/foundation/">Foundation</a></li>
-            <li><a href="/foundation/members.html">Members</a></li>
-            <li><a href="/foundation/blog.html">Blog</a></li>
+            <li><a href="http://nodejs.org/foundation/">Foundation</a></li>
+            <li><a href="http://nodejs.org/foundation/members.html">Members</a></li>
+            <li><a href="http://nodejs.org/foundation/blog.html">Blog</a></li>
           </ul>
           <ul>
             <li><a href="http://nodejs.org/community/">Community</a></li>
@@ -89,7 +89,7 @@
           <ul>
             <li><a href="http://nodejs.org/about/">About</a></li>
             <li><a href="http://nodejs.org/about/organization/">Organization</a></li>
-            <li><a href="/about/releases/">Releases</a></li>
+            <li><a href="http://nodejs.org/about/releases/">Releases</a></li>
             <li><a href="http://nodejs.org/about/resources/">Resources</a></li>
           </ul>
           <ul>

--- a/doc/index.html
+++ b/doc/index.html
@@ -119,9 +119,9 @@ server.listen(1337, '127.0.0.1');</pre>
             <li><a href="http://nodejs.org/contribute/becoming_collaborator.html">Becoming a collaborator</a></li>
           </ul>
             <ul>
-            <li><a href="/foundation/">Foundation</a></li>
-            <li><a href="/foundation/members.html">Members</a></li>
-            <li><a href="/foundation/blog.html">Blog</a></li>
+            <li><a href="http://nodejs.org/foundation/">Foundation</a></li>
+            <li><a href="http://nodejs.org/foundation/members.html">Members</a></li>
+            <li><a href="http://nodejs.org/foundation/blog.html">Blog</a></li>
           </ul>
           <ul>
             <li><a href="http://nodejs.org/community/">Community</a></li>


### PR DESCRIPTION
Using relative links breaks some of the links from the blog page to
other pages. Using absolute links fixes these problems, and makes it
more consistent with the rest.
