### PR TITLE
Fix links in some pages of the "about" section

### DIFF
--- a/doc/about.html
+++ b/doc/about.html
@@ -72,13 +72,13 @@
           <ul>
             <li><a href="http://nodejs.org/contribute/">Contribute</a></li>
             <li><a href="http://nodejs.org/contribute/code_contributions/">Code contributions</a></li>
-            <li><a href="/contribute/accepting_contributions.html">Accepting contributions</a></li>
+            <li><a href="http://nodejs.org/contribute/accepting_contributions.html">Accepting contributions</a></li>
             <li><a href="http://nodejs.org/contribute/becoming_collaborator.html">Becoming a collaborator</a></li>
           </ul>
           <ul>
-            <li><a href="/foundation/">Foundation</a></li>
-            <li><a href="/foundation/members.html">Members</a></li>
-            <li><a href="/foundation/blog.html">Blog</a></li>
+            <li><a href="http://nodejs.org/foundation/">Foundation</a></li>
+            <li><a href="http://nodejs.org/foundation/members.html">Members</a></li>
+            <li><a href="http://nodejs.org/foundation/blog.html">Blog</a></li>
           </ul>
           <ul>
             <li><a href="http://nodejs.org/community/">Community</a></li>

--- a/doc/about/advisory-board/template.html
+++ b/doc/about/advisory-board/template.html
@@ -23,6 +23,8 @@
         <li><a href="/">Home</a></li>
         <li><a href="/download/">Downloads</a></li>
         <li><a href="/documentation/">Docs</a></li>
+        <li><a href="/contribute/">Contribute</a></li>
+        <li><a href="/foundation/">Foundation</a></li>
         <li><a href="/community/">Community</a></li>
         <li><a href="/about/">About</a></li>
         <li><a href="http://jobs.nodejs.org">Jobs</a></li>
@@ -72,6 +74,17 @@
             <li><a href="http://nodejs.org/api/">API Docs</a></li>
             <li><a href="http://nodejs.org/documentation/tutorials/">Tutorials</a></li>
             <li><a href="http://nodejs.org/documentation/localization/">Localization</a></li>
+          </ul>
+          <ul>
+            <li><a href="http://nodejs.org/contribute/">Contribute</a></li>
+            <li><a href="http://nodejs.org/contribute/code_contributions/">Code contributions</a></li>
+            <li><a href="http://nodejs.org/contribute/accepting_contributions.html">Accepting contributions</a></li>
+            <li><a href="http://nodejs.org/contribute/becoming_collaborator.html">Becoming a collaborator</a></li>
+          </ul>
+          <ul>
+            <li><a href="http://nodejs.org/foundation/">Foundation</a></li>
+            <li><a href="http://nodejs.org/foundation/members.html">Members</a></li>
+            <li><a href="http://nodejs.org/foundation/blog.html">Blog</a></li>
           </ul>
           <ul>
             <li><a href="http://nodejs.org/community/">Community</a></li>

--- a/doc/about/organization/template.html
+++ b/doc/about/organization/template.html
@@ -24,6 +24,7 @@
         <li><a href="/download/">Downloads</a></li>
         <li><a href="/documentation/">Docs</a></li>
         <li><a href="/contribute/">Contribute</a></li>
+        <li><a href="/foundation/">Foundation</a></li>
         <li><a href="/community/">Community</a></li>
         <li><a href="/about/">About</a></li>
         <li><a href="http://jobs.nodejs.org">Jobs</a></li>
@@ -76,6 +77,13 @@
           <ul>
             <li><a href="http://nodejs.org/contribute/">Contribute</a></li>
             <li><a href="http://nodejs.org/contribute/code_contributions/">Code contributions</a></li>
+            <li><a href="http://nodejs.org/contribute/accepting_contributions.html">Accepting contributions</a></li>
+            <li><a href="http://nodejs.org/contribute/becoming_collaborator.html">Becoming a collaborator</a></li>
+          </ul>
+          <ul>
+            <li><a href="http://nodejs.org/foundation/">Foundation</a></li>
+            <li><a href="http://nodejs.org/foundation/members.html">Members</a></li>
+            <li><a href="http://nodejs.org/foundation/blog.html">Blog</a></li>
           </ul>
           <ul>
             <li><a href="http://nodejs.org/community/">Community</a></li>

--- a/doc/website.html
+++ b/doc/website.html
@@ -24,6 +24,7 @@
         <li><a href="/download/">Downloads</a></li>
         <li><a href="/documentation/">Docs</a></li>
         <li><a href="/contribute/">Contribute</a></li>
+        <li><a href="/foundation/">Foundation</a></li>
         <li><a href="/community/">Community</a></li>
         <li><a href="/about/">About</a></li>
         <li><a href="http://jobs.nodejs.org">Jobs</a></li>
@@ -56,6 +57,17 @@
             <li><a href="http://nodejs.org/api/">API Docs</a></li>
             <li><a href="http://nodejs.org/documentation/tutorials/">Tutorials</a></li>
             <li><a href="http://nodejs.org/documentation/localization/">Localization</a></li>
+          </ul>
+          <ul>
+            <li><a href="http://nodejs.org/contribute/">Contribute</a></li>
+            <li><a href="http://nodejs.org/contribute/code_contributions/">Code contributions</a></li>
+            <li><a href="http://nodejs.org/contribute/accepting_contributions.html">Accepting contributions</a></li>
+            <li><a href="http://nodejs.org/contribute/becoming_collaborator.html">Becoming a collaborator</a></li>
+          </ul>
+          <ul>
+            <li><a href="http://nodejs.org/foundation/">Foundation</a></li>
+            <li><a href="http://nodejs.org/foundation/members.html">Members</a></li>
+            <li><a href="http://nodejs.org/foundation/blog.html">Blog</a></li>
           </ul>
           <ul>
             <li><a href="http://nodejs.org/community/">Community</a></li>


### PR DESCRIPTION
More fixes for links to "Contribute" and "Foundation" sections from some of the pages in the "About" section.

/cc @joyent/node-website
