### PR TITLE
Community: Remove nodejstr.com

### DIFF
--- a/doc/documentation/localization/index.md
+++ b/doc/documentation/localization/index.md
@@ -29,6 +29,5 @@ localized sites here:
  * [Spanish language community](http://nodehispano.com)
  * [Node.js in Spanish](http://www.nodejs.es)
  * [Taiwan community](http://nodejs.tw)
- * [Node.js in Turkish](http://www.nodejstr.com/)
  * [Node.js in Vietnamese](http://nodejs.vn/)
  * [Nicaragua Node.js community](http://nodenica.com/)


### PR DESCRIPTION
Since it is more like a commercial website which is three people is advertising their commercial consultancy services than a community website; it's better to remove www.nodejstr.com from this list.

Also; there is no information on the website about how to join and contribute to Turkish community.
