### PR TITLE
fix dead link

### DIFF
--- a/doc/about/organization/template.html
+++ b/doc/about/organization/template.html
@@ -100,7 +100,7 @@
           <ul>
             <li><a href="http://nodejs.org/about/">About</a></li>
             <li><a href="http://nodejs.org/about/organization/">Organization</a></li>
-            <li><a href="http://nodejs.org/about/core-team/">Core Team</a></li>
+            <li><a href="http://nodejs.org/about/releases/">Releases</a></li>
             <li><a href="http://nodejs.org/about/resources/">Resources</a></li>
           </ul>
           <ul>


### PR DESCRIPTION
other templates point to `Releases`.

bug spotted on https://nodejs.org/about/organization/
