### PR TITLE
Contributing: point to nodejs/node

### DIFF
--- a/doc/contribute/code_contributions/index.md
+++ b/doc/contribute/code_contributions/index.md
@@ -50,9 +50,7 @@ which is ready for you to start exploring with your changes.
 The following projects are managed by the Node.js team and available for you to
 fork and contribute to.
 
- * [Node.js v0.10 and v0.12](https://github.com/joyent/node)
- * [io.js](https://github.com/nodejs/io.js)
- * [Node.js Next](https://github.com/nodejs/node)
+ * [Node.js (all versions)](https://github.com/nodejs/node)
  * [Node.js Website](https://github.com/joyent/node-website)
  * [http-parser](https://github.com/joyent/http-parser)
 
@@ -70,7 +68,7 @@ upstream repository as a remote that you'll be able to use to refresh your
 version and stay in sync while working on your changes.
 
 ```
-$ git remote add upstream git://github.com/joyent/node.git
+$ git remote add upstream git://github.com/nodejs/node.git
 $ git fetch upstream
 ```
 

--- a/doc/contribute/code_contributions/workflow.md
+++ b/doc/contribute/code_contributions/workflow.md
@@ -60,7 +60,7 @@ followed exactly as they are outlined.
 
 ### Ideal life cycle of a GitHub issue
 
-1. A new issue is filed against the joyent/node issues tracker.
+1. A new issue is filed against the nodejs/node issues tracker.
 
 2. This issue is picked up by a contributor. She assigns the issue to herself if
 she's a collaborator, or leaves it unassigned.

--- a/doc/contribute/index.md
+++ b/doc/contribute/index.md
@@ -27,10 +27,8 @@ repository but don't worry if things happen to get put in the wrong place,
 the community of contributors will be more than happy to help get you
 pointed in the right direction.
 
- * To report issues specific to Node.js v0.10.x or v0.12.x, please use
-   [joyent/node](https://github.com/joyent/node/issues)
- * To report issues specific to io.js (any version), please use [nodejs/io.js](https://github.com/nodejs/io.js/issues)
- * To report issues specific to future Node.js releases, please use [nodejs/node](https://github.com/nodejs/node)
+ * To report issues about Node.js (any version), please use
+   [nodejs/node](https://github.com/nodejs/node/issues)
  * To report issues specific to this website, please use [joyent/node-website](https://github.com/joyent/node-website/issues)
 
 ## Code contributions


### PR DESCRIPTION
Updating a few links to invite people to open issues
on nodejs/node instead of joyent/node.

Ref: https://github.com/nodejs/node-v0.x-archive/issues/25876
